### PR TITLE
added support for (conditional) group overrides. 

### DIFF
--- a/resources/lib/datafunctions.py
+++ b/resources/lib/datafunctions.py
@@ -199,6 +199,17 @@ class DataFunctions():
             # Get the action
             action = node.find( "action" )
             
+            # group overrides: add an additional onclick action for a particular menu
+            # this will allow you to close a modal dialog before calling any other window
+            # http://forum.kodi.tv/showthread.php?tid=224683
+            allGroupOverrides = skinoverrides.findall( "groupoverride" )
+            groupOverrides = []
+            for override in allGroupOverrides:
+                if override.attrib.get( "group" ) == group:
+                    newaction = xmltree.SubElement( node, "additional-action" )
+                    newaction.text = override.text
+                    newaction.set( "condition", override.attrib.get( "condition" ) )
+            
             # Generate the labelID
             labelID = self._get_labelID( self.local( node.find( "label" ).text )[3].replace( " ", "" ).lower(), action.text )
             xmltree.SubElement( node, "labelID" ).text = labelID
@@ -251,7 +262,7 @@ class DataFunctions():
                             checkGroup = None
                             if "group" in elem.attrib:
                                 checkGroup = elem.attrib.get( "group" )
-                                
+
                             # If the action and (if provided) the group match...
                             if elem.attrib.get( "action" ) == action.text and (checkGroup == None or checkGroup == group):
                                 # Check the XBMC version matches

--- a/resources/lib/xmlfunctions.py
+++ b/resources/lib/xmlfunctions.py
@@ -565,7 +565,15 @@ class XMLFunctions():
         visibility = item.find( "visibility" )
         if visibility is not None:
             xmltree.SubElement( newelement, "visible" ).text = visibility.text
-            
+        
+        #additional onclick (group overrides)
+        onclicks = item.findall( "additional-action" )
+        for onclick in onclicks:
+            onclickelement = xmltree.SubElement( newelement, "onclick" )
+            onclickelement.text = onclick.text
+            if "condition" in onclick.attrib:
+                onclickelement.set( "condition", onclick.attrib.get( "condition" ) )
+        
         # Onclick
         onclicks = item.findall( "override-action" )
         if len( onclicks ) == 0:


### PR DESCRIPTION
Added support for group overrides which will solve the issues that exist after the changes in Isengard that a modal dialog should first be closed before opening any other windows.

As discussed here: http://forum.kodi.tv/showthread.php?tid=224683

Usage:

Add an extra entry in your skin's overrides.xml file:

<groupoverride group="powermenu" condition="Window.IsActive(DialogButtonMenu.xml)">Close</groupoverride>

group is the name of the menugroup, for example mainmenu or powermenu etc.
