### PR TITLE
add list property to the output xml to be used for filling a dynamic list

### DIFF
--- a/resources/lib/xmlfunctions.py
+++ b/resources/lib/xmlfunctions.py
@@ -597,10 +597,8 @@ class XMLFunctions():
                             newAction = newAction + "/" + actionPart
                     if len( actionParts ) == 2:
                         onclickelement.text = "ActivateWindow(" + actionParts[0] + "," + newAction + ")"
-                        listproperty = newAction
                     else:
                         onclickelement.text = "ActivateWindow(" + actionParts[0] + "," + newAction + "," + actionParts[2] + ")"
-                        listproperty = newAction + "," + actionParts[2]
                 except:
                     pass
             else:

--- a/resources/lib/xmlfunctions.py
+++ b/resources/lib/xmlfunctions.py
@@ -597,8 +597,10 @@ class XMLFunctions():
                             newAction = newAction + "/" + actionPart
                     if len( actionParts ) == 2:
                         onclickelement.text = "ActivateWindow(" + actionParts[0] + "," + newAction + ")"
+                        listproperty = newAction
                     else:
                         onclickelement.text = "ActivateWindow(" + actionParts[0] + "," + newAction + "," + actionParts[2] + ")"
+                        listproperty = newAction + "," + actionParts[2]
                 except:
                     pass
             else:
@@ -608,6 +610,31 @@ class XMLFunctions():
             pathelement = xmltree.SubElement( newelement, "property" )
             pathelement.set( "name", "path" )
             pathelement.text = onclickelement.text
+            
+            # Also add it as a list property
+            # this will add the real path (without activatewindow) as a property for dynamic listings
+            libPath = onclickelement.text
+            
+            if "$INFO[Window" in libPath:
+                #is this action a window prop ?
+                win = xbmcgui.Window( 10000 )
+                libPath = libPath.replace("$INFO[Window(Home).Property(", "")
+                libPath = libPath.replace(")]", "")
+                libPath = win.getProperty(libPath)    
+            if "$VAR" in libPath:
+                #is this action a skin variable?
+                libPath = xbmc.getInfoLabel(libPath)
+            
+            #only proceed if we have a valid content path
+            if ("," in libPath and ":" in libPath):
+                libPath = libPath.split(",",1)[1]
+                libPath = libPath.replace(",return","")
+                libPath = libPath.replace(", return","")
+                libPath = libPath.replace(")","")
+                libPath = libPath.replace("\"","")
+                pathelement = xmltree.SubElement( newelement, "property" )
+                pathelement.set( "name", "list" )
+                pathelement.text = libPath
                 
             if onclick.text == "ActivateWindow(Settings)":
                 self.hasSettings = True


### PR DESCRIPTION
This was a little request by @HitcherUK to add a list property to the script's output xml file.
What it basically does is add the real path (without the activatewindow and stuff) as a property to the menuitem.

This property value can be used to fill a dynamic list control.
Only "real" library paths are accepted including playlists.Also window properties and skin variables are accepted but they are only evaluated at script build not at runtime.
