### PR TITLE
Fixed UnicodeWarning in comparison of translated <None> label

### DIFF
--- a/resources/lib/gui.py
+++ b/resources/lib/gui.py
@@ -492,7 +492,7 @@ class GUI( xbmcgui.WindowXMLDialog ):
             for listitem in self.allListItems:
                 
                 # If the item has a label...
-                if listitem.getLabel() != __language__(32013):
+                if listitem.getLabel().decode('utf-8') != __language__(32013):
                     # Generate labelID, and mark if it has changed
                     labelID = listitem.getProperty( "labelID" )
                     newlabelID = labelID


### PR DESCRIPTION
A fix for the bug described in http://forum.kodi.tv/showthread.php?tid=178294&pid=2058442#pid2058442

Empty sub-menus should normally be ignored. 
When using some translations the comparison fails and so there is no way to remove the empty sub-menu.

Reason: the translated <None> text is using unicode while the label is a utf-8 encoded string.
