### PR TITLE
skinhelper widgets + fixed scripts not visible in program addons listing

### DIFF
--- a/resources/lib/library.py
+++ b/resources/lib/library.py
@@ -1322,7 +1322,6 @@ class LibraryFunctions():
                         if item['enabled'] == True:                            
                             path = "RunAddOn(" + item['addonid'].encode('utf-8') + ")"
                             action = None
-
                             thumb = "DefaultAddon.png"
                             if item['thumbnail'] != "":
                                 thumb = item[ 'thumbnail' ]
@@ -1387,7 +1386,12 @@ class LibraryFunctions():
                     if provides is None:
                         return None
                     return provides.text.split( " " )
-
+                elif "point" in extension.attrib and extension.attrib.get( "point" ) == "xbmc.python.script":
+                    # Script entry points should be treated as executable
+                    provides = extension.find( "provides" )
+                    if provides is None:
+                        return None
+                    return provides.text.split( " " )
 
         except:
             return None

--- a/resources/shortcuts/overrides.xml
+++ b/resources/shortcuts/overrides.xml
@@ -93,6 +93,10 @@
 	</flatgroupings>
 	
 	<groupings>
+        
+        <!-- script.skin.helper.service smart shortcuts -->
+        <shortcut label="$ADDON[script.skin.helper.service 32062]" type="32010" condition="System.HasAddon(script.skin.helper.service)">||BROWSE||script.skin.helper.service/?action=smartshortcuts</shortcut>
+        
 		<node label="32029">
 			<content>common</content>
 		</node>
@@ -178,7 +182,10 @@
 	</groupings>
 
 	<widget-groupings>
-		<content>widgets</content>
+        <!-- script.skin.helper.service default widgets -->
+        <shortcut label="$ADDON[script.skin.helper.service 32063]" type="32010" condition="System.HasAddon(script.skin.helper.service)">||BROWSE||script.skin.helper.service/?action=widgets&amp;path=skinplaylists,librarydataprovider,scriptwidgets,extendedinfo,smartshortcuts,pvr,smartishwidgets</shortcut>
+	
+        <content>widgets</content>
 		<node label="32030">
 			<content>video</content>
 			<node label="32040">


### PR DESCRIPTION
1) add skinhelper script widgets by default to the overrides.xml
2) fixed small issue that program-addons was not showing scripts as executables in the listing
