### PR TITLE
RTL Support for keyboard dialog

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -11,6 +11,7 @@ v0.6.4
 - [tomer953] Remove requirement for ::ACTION:: in action override to be the only text in element
 - [tomer953] Management dialog - Insert new menu in the current location instead of add them at the end
 - Minor bug fixes
+- [tomer953] RTL Support - reverse string before inserting them to the keyboard dialog as a workaround to a kodi bug.
 
 v0.6.0
 - Version bump for Isengard repo.

--- a/resources/lib/gui.py
+++ b/resources/lib/gui.py
@@ -48,6 +48,14 @@ def log(txt):
         except:
             pass
 
+def is_hebrew(text):
+    if type(text) != unicode:
+        text = text.decode('utf-8')
+    for chr in text:
+        if ord(chr) >= 1488 and ord(chr) <= 1514:
+            return True
+    return False
+
 class GUI( xbmcgui.WindowXMLDialog ):
     def __init__( self, *args, **kwargs ):
         self.group = kwargs[ "group" ]
@@ -1001,6 +1009,8 @@ class GUI( xbmcgui.WindowXMLDialog ):
                 label = ""
                 
             # Get new label from keyboard dialog
+            if is_hebrew(label):
+                label = label.decode('utf-8')[::-1]
             keyboard = xbmc.Keyboard( label, xbmc.getLocalizedString(528), False )
             keyboard.doModal()
             if ( keyboard.isConfirmed() ):
@@ -1277,6 +1287,8 @@ class GUI( xbmcgui.WindowXMLDialog ):
                         widgetTempName = xbmc.getInfoLabel(widgetName)
                     else:
                         widgetTempName = DATA.local( widgetName )[2]
+                    if is_hebrew(widgetTempName):
+                        widgetTempName = widgetTempName[::-1]
                     keyboard = xbmc.Keyboard( widgetTempName, xbmc.getLocalizedString(16105), False )
                     keyboard.doModal()
                     if ( keyboard.isConfirmed() ) and keyboard.getText != "":


### PR DESCRIPTION
As a workaround to a Kodi bug, which reverse string in RTL Languages, we
check if string is in RTL Language and reverse it order to display it
right.
