### PR TITLE
remove default Library.HasContent visibility checks for main music and musicvideos node

### DIFF
--- a/resources/lib/datafunctions.py
+++ b/resources/lib/datafunctions.py
@@ -778,24 +778,6 @@ class DataFunctions():
                 path[ 1 ] = path[ 1 ][:-1]
             return NODE.get_visibility( path[ 1 ] )
 
-        # Isengard and earlier music library
-        elif action.startswith( "activatewindow(musiclibrary,addons" ):
-            return ""
-        elif action.startswith( "activatewindow(musiclibrary,musicvideo" ):
-            return "Library.HasContent(MusicVideos)"
-        elif action.startswith( "activatewindow(musiclibrary," ):
-            return "Library.HasContent(Music)"
-
-        # Jarvis and later music library
-        elif action.startswith( "activatewindow(music,addons" ) or action.startswith( "activatewindow(music,files" ):
-            return ""
-        elif action.startswith( "activatewindow(music,musicvideo" ):
-            return "Library.HasContent(MusicVideos)"
-        elif action == "activatewindow(music)" or action.startswith( "activatewindow(music,root" ):
-            return ""
-        elif action.startswith( "activatewindow(music,"):
-            return "Library.HasContent(Music)"
-
         # Power menu visibilities
         elif action == "quit()" or action == "quit":
             return "System.ShowExitButton"

--- a/resources/lib/xmlfunctions.py
+++ b/resources/lib/xmlfunctions.py
@@ -239,10 +239,6 @@ class XMLFunctions():
                     if profilelist != hash[1]:
                         log( "Profiles have changes" )
                         return True
-                elif hash[0] == "::MUSICCONTENT::":
-                    # Check if Library.HasContent(Music) has changed
-                    if xbmc.getCondVisibility( "Library.HasContent(Music)" ) != hash[1]:
-                        log( "Whether there is music in the library has changed" )
                 elif hash[0] == "::HIDEPVR::":
                     checkedPVRVis = True
                     if __addon__.getSetting( "donthidepvr" ) != hash[1]:
@@ -307,8 +303,6 @@ class XMLFunctions():
         hashlist.list.append( ["::PROFILELIST::", profilelist] )
         hashlist.list.append( ["::SCRIPTVER::", __addonversion__] )
         hashlist.list.append( ["::XBMCVER::", __xbmcversion__] )
-        if int( __xbmcversion__ ) <= 15:
-            hashlist.list.append( ["::MUSICCONTENT::", xbmc.getCondVisibility( "Library.HasContent(Music)" ) ] )
         hashlist.list.append( ["::HIDEPVR::",  __addon__.getSetting( "donthidepvr" )] )
         hashlist.list.append( ["::SHARED::", __addon__.getSetting( "shared_menu" )] )
         hashlist.list.append( ["::SKINDIR::", xbmc.getSkinDir()] )


### PR DESCRIPTION
@Ignoble61 as discussed, this removes the visibility conditions for the music shortcuts as it causes a lot of confusion these days
