### PR TITLE
Hide home button if on home

### DIFF
--- a/resources/lib/datafunctions.py
+++ b/resources/lib/datafunctions.py
@@ -873,6 +873,8 @@ class DataFunctions():
             return "[System.Platform.Windows | System.Platform.Linux] +! System.Platform.Linux.RaspberryPi"
 
         # General visibilities
+        elif action == "activatewindow(home)":
+            return "!Window.IsVisible(home)"
         elif action == "activatewindow(weather)" and int( KODIVERSION ) >= 17:
             return "!String.IsEmpty(Weather.Plugin)"
         elif action == "activatewindow(weather)":


### PR DESCRIPTION
I can't see a way to create a custom 'visible' for menu items, so in this case the home button is useless on homepage. IF there is a way to do this then ignore [apart from making another menu just for home?].