### PR TITLE
Initial Python 3 support

### DIFF
--- a/default.py
+++ b/default.py
@@ -2,12 +2,12 @@
 import os, sys
 import xbmc, xbmcaddon, xbmcgui, xbmcplugin, urllib, xbmcvfs
 import xml.etree.ElementTree as xmltree
-import cPickle as pickle
+import pickle
 import pstats
 import random
 import time
 import calendar
-import thread
+import _thread
 from time import gmtime, strftime
 from datetime import datetime
 from traceback import print_exc
@@ -21,14 +21,14 @@ else:
     import json as simplejson
 
 ADDON        = xbmcaddon.Addon()
-ADDONID      = ADDON.getAddonInfo('id').decode( 'utf-8' )
+ADDONID      = ADDON.getAddonInfo('id')
 ADDONVERSION = ADDON.getAddonInfo('version')
 LANGUAGE     = ADDON.getLocalizedString
-CWD          = ADDON.getAddonInfo('path').decode("utf-8")
-ADDONNAME    = ADDON.getAddonInfo('name').decode("utf-8")
-RESOURCE     = xbmc.translatePath( os.path.join( CWD, 'resources', 'lib' ) ).decode("utf-8")
-DATAPATH     = os.path.join( xbmc.translatePath( "special://profile/" ).decode( 'utf-8' ), "addon_data", ADDONID )
-MASTERPATH   = os.path.join( xbmc.translatePath( "special://masterprofile/" ).decode( 'utf-8' ), "addon_data", ADDONID )
+CWD          = ADDON.getAddonInfo('path')
+ADDONNAME    = ADDON.getAddonInfo('name')
+RESOURCE     = xbmc.translatePath( os.path.join( CWD, 'resources', 'lib' ) )
+DATAPATH     = os.path.join( xbmc.translatePath( "special://profile/" ), "addon_data", ADDONID )
+MASTERPATH   = os.path.join( xbmc.translatePath( "special://masterprofile/" ), "addon_data", ADDONID )
 
 sys.path.append(RESOURCE)
 
@@ -159,7 +159,7 @@ class Main:
 
             elif selectedShortcut.getProperty( "Path" ) and selectedShortcut.getProperty( "custom" ) == "true":
                 # The user updated the path - so we just set that property
-                xbmc.executebuiltin( "Skin.SetString(%s,%s)" %( self.WIDGETPATH, urllib.unquote( selectedShortcut.getProperty( "Path" ) ) ) )
+                xbmc.executebuiltin( "Skin.SetString(%s,%s)" %( self.WIDGETPATH, urllib.parse.unquote( selectedShortcut.getProperty( "Path" ) ) ) )
 
             elif selectedShortcut.getProperty( "Path" ):
                 # The user selected the widget they wanted
@@ -185,7 +185,7 @@ class Main:
                         xbmc.executebuiltin( "Skin.Reset(%s)" %( self.WIDGETTARGET ) )
                 if self.WIDGETPATH:
                     if selectedShortcut.getProperty( "widgetPath" ):
-                        xbmc.executebuiltin( "Skin.SetString(%s,%s)" %( self.WIDGETPATH, urllib.unquote( selectedShortcut.getProperty( "widgetPath" ) ) ) )
+                        xbmc.executebuiltin( "Skin.SetString(%s,%s)" %( self.WIDGETPATH, selectedShortcut.getProperty( "widgetPath" ) ) )
                     else:
                         xbmc.executebuiltin( "Skin.Reset(%s)" %( self.WIDGETPATH ) )
 
@@ -275,15 +275,15 @@ class Main:
         self.DEFAULTGROUP = params.get( "defaultGroup", None )
 
         # Properties from context menu addon
-        self.CONTEXTFILENAME = urllib.unquote( params.get( "filename", "" ) )
+        self.CONTEXTFILENAME = urllib.parse.unquote( params.get( "filename", "" ) )
         self.CONTEXTLABEL = params.get( "label", "" )
         self.CONTEXTICON = params.get( "icon", "" )
         self.CONTEXTCONTENT = params.get( "content", "" )
         self.CONTEXTWINDOW = params.get( "window", "" )
 
         # Properties from external request to set properties
-        self.PROPERTIES = urllib.unquote( params.get( "property", "" ) )
-        self.VALUES = urllib.unquote( params.get( "value", "" ) )
+        self.PROPERTIES = urllib.parse.unquote( params.get( "property", "" ) )
+        self.VALUES = urllib.parse.unquote( params.get( "value", "" ) )
         self.LABELID = params.get( "labelID", "" )
     
     
@@ -292,7 +292,7 @@ class Main:
     # -----------------
 
     def _launch_shortcut( self, path ):
-        action = urllib.unquote( self.PATH )
+        action = urllib.parse.unquote( self.PATH )
         
         if action.find("::MULTIPLE::") == -1:
             # Single action, run it
@@ -388,7 +388,7 @@ class Main:
         if count != 0:
             xbmc.executebuiltin( "Control.Move(" + menuid + "," + str( count ) + " )" )
             
-        xbmc.executebuiltin( urllib.unquote( action ) )
+        xbmc.executebuiltin( urllib.parse.unquote( action ) )
         
 if ( __name__ == "__main__" ):
     log('script version %s started' % ADDONVERSION)

--- a/resources/lib/datafunctions.py
+++ b/resources/lib/datafunctions.py
@@ -6,7 +6,7 @@ import hashlib, hashlist
 import ast
 from xml.dom.minidom import parse
 from traceback import print_exc
-from htmlentitydefs import name2codepoint
+from html.entities import name2codepoint
 from unidecode import unidecode
 from unicodeutils import try_decode
 
@@ -14,13 +14,13 @@ import nodefunctions
 NODE = nodefunctions.NodeFunctions()
 
 ADDON        = xbmcaddon.Addon()
-ADDONID      = ADDON.getAddonInfo('id').decode( 'utf-8' )
+ADDONID      = ADDON.getAddonInfo('id')
 KODIVERSION  = xbmc.getInfoLabel( "System.BuildVersion" ).split(".")[0]
 LANGUAGE     = ADDON.getLocalizedString
-CWD          = ADDON.getAddonInfo('path').decode("utf-8")
-DATAPATH     = os.path.join( xbmc.translatePath( "special://profile/addon_data/" ).decode('utf-8'), ADDONID )
-SKINPATH     = xbmc.translatePath( "special://skin/shortcuts/" ).decode('utf-8')
-DEFAULTPATH  = xbmc.translatePath( os.path.join( CWD, 'resources', 'shortcuts').encode("utf-8") ).decode("utf-8")
+CWD          = ADDON.getAddonInfo('path')
+DATAPATH     = os.path.join( xbmc.translatePath( "special://profile/addon_data/" ), ADDONID )
+SKINPATH     = xbmc.translatePath( "special://skin/shortcuts/" )
+DEFAULTPATH  = xbmc.translatePath( os.path.join( CWD, 'resources', 'shortcuts').encode("utf-8") )
 
 # character entity reference
 CHAR_ENTITY_REXP = re.compile('&(%s);' % '|'.join(name2codepoint))
@@ -132,7 +132,7 @@ class DataFunctions():
         log( "Loading shortcuts for group " + group )
                 
         if profileDir is None:
-            profileDir = xbmc.translatePath( "special://profile/" ).decode( "utf-8" )
+            profileDir = xbmc.translatePath( "special://profile/" )
         
         userShortcuts = os.path.join( profileDir, "addon_data", ADDONID, self.slugify( group, True, isSubLevel = isSubLevel ) + ".DATA.xml" )
         skinShortcuts = os.path.join( SKINPATH , self.slugify( group ) + ".DATA.xml")
@@ -548,7 +548,7 @@ class DataFunctions():
         self.currentProperties = []
         self.defaultProperties = []
         
-        path = os.path.join( profileDir, "addon_data", ADDONID, xbmc.getSkinDir().decode('utf-8') + ".properties" ).encode( "utf-8" )
+        path = os.path.join( profileDir, "addon_data", ADDONID, xbmc.getSkinDir() + ".properties" ).encode( "utf-8" )
         #path = os.path.join( DATAPATH , xbmc.getSkinDir().decode('utf-8') + ".properties" )
         if xbmcvfs.exists( path ):
             # The properties file exists, load from it
@@ -787,22 +787,16 @@ class DataFunctions():
     def createNiceName ( self, item, noNonLocalized = False ):
         # Translate certain localized strings into non-localized form for labelID
         if noNonLocalized == False:
-            if int( KODIVERSION ) >= 18:
-                if item == "3":
-                    return "videos"
-                if item == "2":
-                    return "music"
-            else:
-                if item == "10006":
-                    return "videos"
-                if item == "10005":
-                    return "music"
+            if item == "10006":
+                return "videos"
             if item == "342":
                 return "movies"
             if item == "20343":
                 return "tvshows"
             if item == "32022":
                 return "livetv"
+            if item == "10005":
+                return "music"
             if item == "20389":
                 return "musicvideos"
             if item == "10002":
@@ -867,8 +861,6 @@ class DataFunctions():
             return "System.CanHibernate"
         elif action == "reset()" or action == "reset":
             return "System.CanReboot"
-        elif action == "system.logoff" and int( KODIVERSION ) >= 17:
-            return "[System.HasLoginScreen | Integer.IsGreater(System.ProfileCount,1)] + System.Loggedon"
         elif action == "system.logoff":
             return "[System.HasLoginScreen | IntegerGreaterThan(System.ProfileCount,1)] + System.Loggedon"
         elif action == "mastermode":
@@ -1029,7 +1021,7 @@ class DataFunctions():
             if files:
                 for file in files:
                     if file.endswith( ".hash" ) and not file.startswith( "%s-" %( xbmc.getSkinDir() ) ):
-                        canImport, skinName = self.parseHashFile( os.path.join( DATAPATH, file.decode( 'utf-8' ) ).encode( 'utf-8' ) )
+                        canImport, skinName = self.parseHashFile( os.path.join( DATAPATH, file ).encode( 'utf-8' ) )
                         if canImport == True:
                             skinNames.append( skinName )
                     elif file.endswith( ".DATA.xml" ) and not file.startswith( "%s-" %( xbmc.getSkinDir() ) ):
@@ -1099,8 +1091,8 @@ class DataFunctions():
                 newFile = oldFile.replace( skinName, xbmc.getSkinDir() )
             else:
                 newFile = "%s-%s" %( xbmc.getSkinDir(), oldFile )
-            oldPath = os.path.join( DATAPATH, oldFile.decode( 'utf-8' ) ).encode( 'utf-8' )
-            newPath = os.path.join( DATAPATH, newFile.decode( 'utf-8' ) ).encode( 'utf-8' )
+            oldPath = os.path.join( DATAPATH, oldFile ).encode( 'utf-8' )
+            newPath = os.path.join( DATAPATH, newFile ).encode( 'utf-8' )
 
             # Copy file
             xbmcvfs.copy( oldPath, newPath )

--- a/resources/lib/library.py
+++ b/resources/lib/library.py
@@ -2,7 +2,7 @@
 import os, sys, datetime, unicodedata
 import xbmc, xbmcgui, xbmcvfs, urllib
 import xml.etree.ElementTree as xmltree
-import thread
+import _thread
 from xml.dom.minidom import parse
 from xml.sax.saxutils import escape as escapeXML
 from traceback import print_exc
@@ -20,7 +20,7 @@ else:
 ADDON        = sys.modules[ "__main__" ].ADDON
 ADDONID      = sys.modules[ "__main__" ].ADDONID
 CWD          = sys.modules[ "__main__" ].CWD
-DATAPATH     = os.path.join( xbmc.translatePath( "special://profile/addon_data/" ).decode('utf-8'), ADDONID )
+DATAPATH     = os.path.join( xbmc.translatePath( "special://profile/addon_data/" ), ADDONID )
 LANGUAGE     = sys.modules[ "__main__" ].LANGUAGE
 KODIVERSION  = xbmc.getInfoLabel( "System.BuildVersion" ).split(".")[0]
 
@@ -714,11 +714,11 @@ class LibraryFunctions():
             prefix = "library://music"
             action = "||AUDIO||"
 
-        rootdir = os.path.join( xbmc.translatePath( "special://profile".decode('utf-8') ), "library", library )
+        rootdir = os.path.join( xbmc.translatePath( "special://profile" ), "library", library )
         if type == "custom":
             log( "Listing custom %s nodes..." %( library ) )
         else:
-            rootdir = os.path.join( xbmc.translatePath( "special://xbmc".decode('utf-8') ), "system", "library", library )
+            rootdir = os.path.join( xbmc.translatePath( "special://xbmc" ), "system", "library", library )
             log( "Listing default %s nodes..." %( library ) )
             
         nodes = NODE.get_nodes( rootdir, prefix )
@@ -763,20 +763,14 @@ class LibraryFunctions():
         # Videos, Movies, TV Shows, Live TV, Music, Music Videos, Pictures, Weather, Programs,
         # Play dvd, eject tray
         # Settings, File Manager, Profiles, System Info
-        if int( KODIVERSION ) >= 18:
-            listitems.append( self._create(["ActivateWindow(Videos)", "3", "32034", {"icon": "DefaultVideo.png"} ]) )
-        else:
-            listitems.append( self._create(["ActivateWindow(Videos)", "10006", "32034", {"icon": "DefaultVideo.png"} ]) )
+        listitems.append( self._create(["ActivateWindow(Videos)", "10006", "32034", {"icon": "DefaultVideo.png"} ]) )
         listitems.append( self._create(["ActivateWindow(Videos,videodb://movies/titles/,return)", "342", "32034", {"icon": "DefaultMovies.png"} ]) )
         listitems.append( self._create(["ActivateWindow(Videos,videodb://tvshows/titles/,return)", "20343", "32034", {"icon": "DefaultTVShows.png"} ]) )
 
         listitems.append( self._create(["ActivateWindow(TVGuide)", "32022", "32034", {"icon": "DefaultTVShows.png"} ]) )
         listitems.append( self._create(["ActivateWindow(RadioGuide)", "32087", "32034", {"icon": "DefaultTVShows.png"} ]) )
         
-        if int( KODIVERSION ) >= 18:
-            listitems.append( self._create(["ActivateWindow(Music)", "2", "32034", {"icon": "DefaultMusicAlbums.png"} ]) )
-        else:
-            listitems.append( self._create(["ActivateWindow(Music)", "10005", "32034", {"icon": "DefaultMusicAlbums.png"} ]) )
+        listitems.append( self._create(["ActivateWindow(Music)", "10005", "32034", {"icon": "DefaultMusicAlbums.png"} ]) )
         listitems.append( self._create(["PlayerControl(PartyMode)", "589", "32034", {"icon": "DefaultMusicAlbums.png"} ]) )
         listitems.append( self._create(["PlayerControl(PartyMode(Video))", "32108", "32034", {"icon": "DefaultMusicVideos.png"} ]) )
 
@@ -795,7 +789,7 @@ class LibraryFunctions():
 
         if int( KODIVERSION ) >= 16:
             listitems.append( self._create(["ActivateWindow(EventLog,events://,return)", "14111", "32034", {"icon": "Events.png"} ]) )
-
+        
         listitems.append( self._create(["ActivateWindow(Favourites)", "1036", "32034", {"icon": "Favourites.png"} ]) )
             
         self.addToDictionary( "common", listitems )
@@ -991,12 +985,12 @@ class LibraryFunctions():
                 try:
                     playlist = file['path']
                     label = file['label']
-                    playlistfile = xbmc.translatePath( playlist ).decode('utf-8')
+                    playlistfile = xbmc.translatePath( playlist )
                     mediaLibrary = path[2]
                     
                     if playlist.endswith( '.xsp' ):
                         contents = xbmcvfs.File(playlistfile, 'r')
-                        contents_data = contents.read().decode('utf-8')
+                        contents_data = contents.read()
                         xmldata = xmltree.fromstring(contents_data.encode('utf-8'))
                         mediaType = "unknown"
                         for line in xmldata.getiterator():
@@ -1077,11 +1071,11 @@ class LibraryFunctions():
             for file in kodiwalk( path ):
                 playlist = file['path']
                 label = file['label']
-                playlistfile = xbmc.translatePath( playlist ).decode('utf-8')
+                playlistfile = xbmc.translatePath( playlist )
                 
                 if playlist.endswith( '-randomversion.xsp' ):
                     contents = xbmcvfs.File(playlistfile, 'r')
-                    contents_data = contents.read().decode('utf-8')
+                    contents_data = contents.read()
                     xmldata = xmltree.fromstring(contents_data.encode('utf-8'))
                     for line in xmldata.getiterator():                               
                         if line.tag == "name":
@@ -1105,7 +1099,7 @@ class LibraryFunctions():
         listitems = []
         listing = None
         
-        fav_file = xbmc.translatePath( 'special://profile/favourites.xml' ).decode("utf-8")
+        fav_file = xbmc.translatePath( 'special://profile/favourites.xml' )
         if xbmcvfs.exists( fav_file ):
             doc = parse( fav_file )
             listing = doc.documentElement.getElementsByTagName( 'favourite' )
@@ -1930,7 +1924,7 @@ class LibraryFunctions():
                 if not image and item.get("file",""):
                     image = item["file"]
                 if image:
-                    image = urllib.unquote(image).decode('utf8')
+                    image = urllib.unquote(image)
                     if "$INFO" in image:
                         image = image.replace("image://","")
                         if image.endswith("/"):

--- a/resources/lib/nodefunctions.py
+++ b/resources/lib/nodefunctions.py
@@ -3,10 +3,10 @@ import os, sys, datetime, unicodedata, re, types
 import xbmc, xbmcaddon, xbmcgui, xbmcvfs, urllib
 import xml.etree.ElementTree as xmltree
 import hashlib, hashlist
-import cPickle as pickle
+import pickle
 from xml.dom.minidom import parse
 from traceback import print_exc
-from htmlentitydefs import name2codepoint
+from html.entities import name2codepoint
 from unidecode import unidecode
 from unicodeutils import try_decode
 
@@ -16,11 +16,11 @@ else:
     import json as simplejson
 
 ADDON        = xbmcaddon.Addon()
-ADDONID      = ADDON.getAddonInfo('id').decode( 'utf-8' )
+ADDONID      = ADDON.getAddonInfo('id')
 KODIVERSION  = xbmc.getInfoLabel( "System.BuildVersion" ).split(".")[0]
 LANGUAGE     = ADDON.getLocalizedString
-CWD          = ADDON.getAddonInfo('path').decode("utf-8")
-DATAPATH     = os.path.join( xbmc.translatePath( "special://profile/addon_data/" ).decode('utf-8'), ADDONID )
+CWD          = ADDON.getAddonInfo('path')
+DATAPATH     = os.path.join( xbmc.translatePath( "special://profile/addon_data/" ), ADDONID )
 
 # character entity reference
 CHAR_ENTITY_REXP = re.compile('&(%s);' % '|'.join(name2codepoint))
@@ -61,7 +61,7 @@ class NodeFunctions():
             for dir in dirs:
                 self.parse_node( os.path.join( path, dir ), dir, nodes, prefix )
             for file in files:
-                self.parse_view( os.path.join( path, file.decode( "utf-8" ) ), nodes, origPath = "%s/%s" % ( prefix, file ), prefix = prefix )
+                self.parse_view( os.path.join( path, file ), nodes, origPath = "%s/%s" % ( prefix, file ), prefix = prefix )
         except:
             print_exc()
             return False
@@ -140,10 +140,10 @@ class NodeFunctions():
             print_exc()
             
     def isGrouped( self, path ):        
-        customPathVideo = path.replace( "library://video", os.path.join( xbmc.translatePath( "special://profile".decode('utf-8') ), "library", "video" ) )[:-1]
-        defaultPathVideo = path.replace( "library://video", os.path.join( xbmc.translatePath( "special://xbmc".decode('utf-8') ), "system", "library", "video" ) )[:-1]
-        customPathAudio = path.replace( "library://music", os.path.join( xbmc.translatePath( "special://profile".decode('utf-8') ), "library", "music" ) )[:-1]
-        defaultPathAudio = path.replace( "library://music", os.path.join( xbmc.translatePath( "special://xbmc".decode('utf-8') ), "system", "library", "music" ) )[:-1]
+        customPathVideo = path.replace( "library://video", os.path.join( xbmc.translatePath( "special://profile" ), "library", "video" ) )[:-1]
+        defaultPathVideo = path.replace( "library://video", os.path.join( xbmc.translatePath( "special://xbmc" ), "system", "library", "video" ) )[:-1]
+        customPathAudio = path.replace( "library://music", os.path.join( xbmc.translatePath( "special://profile" ), "library", "music" ) )[:-1]
+        defaultPathAudio = path.replace( "library://music", os.path.join( xbmc.translatePath( "special://xbmc" ), "system", "library", "music" ) )[:-1]
         
         paths = [ customPathVideo, defaultPathVideo, customPathAudio, defaultPathAudio ]
         foundPath = False
@@ -191,10 +191,10 @@ class NodeFunctions():
         else:
             return ""
 
-        customPath = path.replace( pathStart, os.path.join( xbmc.translatePath( "special://profile".decode('utf-8') ), "library", pathEnd ) ) + "index.xml"
-        customFile = path.replace( pathStart, os.path.join( xbmc.translatePath( "special://profile".decode('utf-8') ), "library", pathEnd ) )[:-1] + ".xml"
-        defaultPath = path.replace( pathStart, os.path.join( xbmc.translatePath( "special://xbmc".decode('utf-8') ), "system", "library", pathEnd ) ) + "index.xml"
-        defaultFile = path.replace( pathStart, os.path.join( xbmc.translatePath( "special://xbmc".decode('utf-8') ), "system", "library", pathEnd ) )[:-1] + ".xml"
+        customPath = path.replace( pathStart, os.path.join( xbmc.translatePath( "special://profile" ), "library", pathEnd ) ) + "index.xml"
+        customFile = path.replace( pathStart, os.path.join( xbmc.translatePath( "special://profile" ), "library", pathEnd ) )[:-1] + ".xml"
+        defaultPath = path.replace( pathStart, os.path.join( xbmc.translatePath( "special://xbmc" ), "system", "library", pathEnd ) ) + "index.xml"
+        defaultFile = path.replace( pathStart, os.path.join( xbmc.translatePath( "special://xbmc" ), "system", "library", pathEnd ) )[:-1] + ".xml"
 
         # Check whether the node exists - either as a parent node (with an index.xml) or a view node (append .xml)
         # in first custom video nodes, then default video nodes
@@ -212,8 +212,8 @@ class NodeFunctions():
         if path.endswith( "/" ): path = path[ :-1 ]
         path = path.rsplit( "/", 1 )[ 0 ]
 
-        customPath = path.replace( pathStart, os.path.join( xbmc.translatePath( "special://profile".decode('utf-8') ), "library", pathEnd ) ) + "/index.xml"
-        defaultPath = path.replace( pathStart, os.path.join( xbmc.translatePath( "special://xbmc".decode('utf-8') ), "system", "library", pathEnd ) ) + "/index.xml"
+        customPath = path.replace( pathStart, os.path.join( xbmc.translatePath( "special://profile" ), "library", pathEnd ) ) + "/index.xml"
+        defaultPath = path.replace( pathStart, os.path.join( xbmc.translatePath( "special://xbmc" ), "system", "library", pathEnd ) ) + "/index.xml"
         nodeParent = None
         if xbmcvfs.exists( customPath ):
             nodeParent = customPath
@@ -256,10 +256,10 @@ class NodeFunctions():
         else:
             return "unknown"
 
-        customPath = path.replace( pathStart, os.path.join( xbmc.translatePath( "special://profile".decode('utf-8') ), "library", pathEnd ) ) + "index.xml"
-        customFile = path.replace( pathStart, os.path.join( xbmc.translatePath( "special://profile".decode('utf-8') ), "library", pathEnd ) )[:-1] + ".xml"
-        defaultPath = path.replace( pathStart, os.path.join( xbmc.translatePath( "special://xbmc".decode('utf-8') ), "system", "library", pathEnd ) ) + "index.xml"
-        defaultFile = path.replace( pathStart, os.path.join( xbmc.translatePath( "special://xbmc".decode('utf-8') ), "system", "library", pathEnd ) )[:-1] + ".xml"
+        customPath = path.replace( pathStart, os.path.join( xbmc.translatePath( "special://profile" ), "library", pathEnd ) ) + "index.xml"
+        customFile = path.replace( pathStart, os.path.join( xbmc.translatePath( "special://profile" ), "library", pathEnd ) )[:-1] + ".xml"
+        defaultPath = path.replace( pathStart, os.path.join( xbmc.translatePath( "special://xbmc" ), "system", "library", pathEnd ) ) + "index.xml"
+        defaultFile = path.replace( pathStart, os.path.join( xbmc.translatePath( "special://xbmc" ), "system", "library", pathEnd ) )[:-1] + ".xml"
         
         # Check whether the node exists - either as a parent node (with an index.xml) or a view node (append .xml)
         # in first custom video nodes, then default video nodes
@@ -491,7 +491,7 @@ class NodeFunctions():
             return
 
         # Load the properties
-        currentProperties, defaultProperties = DATA._get_additionalproperties( xbmc.translatePath( "special://profile/" ).decode( "utf-8" ) )
+        currentProperties, defaultProperties = DATA._get_additionalproperties( xbmc.translatePath( "special://profile/" ) )
         otherProperties, requires, templateOnly = DATA._getPropertyRequires()
 
         # If there aren't any currentProperties, use the defaultProperties instead
@@ -538,7 +538,7 @@ class NodeFunctions():
         
         # Save the new properties
         try:
-            f = xbmcvfs.File( os.path.join( DATAPATH , xbmc.getSkinDir().decode('utf-8') + ".properties" ), 'w' )
+            f = xbmcvfs.File( os.path.join( DATAPATH , xbmc.getSkinDir() + ".properties" ), 'w' )
             f.write( repr( saveData ).replace( "],", "],\n" ) )
             f.close()
             log( "Properties file saved succesfully" )

--- a/resources/lib/template.py
+++ b/resources/lib/template.py
@@ -9,8 +9,8 @@ import simpleeval, operator, ast
 from simpleeval import simple_eval
 
 ADDON        = xbmcaddon.Addon()
-ADDONID      = ADDON.getAddonInfo('id').decode( 'utf-8' )
-SKINPATH     = xbmc.translatePath( "special://skin/shortcuts/" ).decode('utf-8')
+ADDONID      = ADDON.getAddonInfo('id')
+SKINPATH     = xbmc.translatePath( "special://skin/shortcuts/" )
 
 STRINGCOMPARE = "StringCompare"
 if int( xbmc.getInfoLabel( "System.BuildVersion" ).split(".")[0] ) >= 17:

--- a/resources/lib/xmlfunctions.py
+++ b/resources/lib/xmlfunctions.py
@@ -16,7 +16,7 @@ ADDON        = xbmcaddon.Addon()
 ADDONID      = sys.modules[ "__main__" ].ADDONID
 ADDONVERSION = ADDON.getAddonInfo('version')
 KODIVERSION  = xbmc.getInfoLabel( "System.BuildVersion" ).split(".")[0]
-MASTERPATH   = os.path.join( xbmc.translatePath( "special://masterprofile/addon_data/" ).decode('utf-8'), ADDONID ).encode('utf-8')
+MASTERPATH   = os.path.join( xbmc.translatePath( "special://masterprofile/addon_data/" ), ADDONID )
 LANGUAGE     = ADDON.getLocalizedString
 
 STRINGCOMPARE = "StringCompare"
@@ -32,7 +32,7 @@ def log(txt):
         if isinstance (txt,str):
             txt = txt.decode('utf-8')
         message = u'%s: %s' % (ADDONID, txt)
-        xbmc.log(msg=message.encode('utf-8'), level=xbmc.LOGDEBUG)
+        xbmc.log(msg=message, level=xbmc.LOGDEBUG)
     
 class XMLFunctions():
     def __init__(self):
@@ -57,7 +57,7 @@ class XMLFunctions():
         xbmcgui.Window( 10000 ).setProperty( "skinshortcuts-isrunning", "True" )
  
         # Get a list of profiles
-        fav_file = xbmc.translatePath( 'special://userdata/profiles.xml' ).decode("utf-8")
+        fav_file = xbmc.translatePath( 'special://userdata/profiles.xml' )
         tree = None
         if xbmcvfs.exists( fav_file ):
             f = xbmcvfs.File( fav_file )
@@ -67,16 +67,16 @@ class XMLFunctions():
         if tree is not None:
             profiles = tree.findall( "profile" )
             for profile in profiles:
-                name = profile.find( "name" ).text.encode( "utf-8" )
-                dir = profile.find( "directory" ).text.encode( "utf-8" )
+                name = profile.find( "name" ).text
+                dir = profile.find( "directory" ).text
                 log( "Profile found: " + name + " (" + dir + ")" )
                 # Localise the directory
                 if "://" in dir:
-                    dir = xbmc.translatePath( dir ).decode( "utf-8" )
+                    dir = xbmc.translatePath( dir )
                 else:
                     # Base if off of the master profile
-                    dir = xbmc.translatePath( os.path.join( "special://masterprofile", dir ) ).decode( "utf-8" )
-                profilelist.append( [ dir, "%s(System.ProfileName,%s)" %( STRINGCOMPARE, name.decode( "utf-8" ) ), name.decode( "utf-8" ) ] )
+                    dir = xbmc.translatePath( os.path.join( "special://masterprofile", dir ) )
+                profilelist.append( [ dir, "%s(System.ProfileName,%s)" %( STRINGCOMPARE, name ), name ] )
                 
         else:
             profilelist = [["special://masterprofile", None]]
@@ -173,7 +173,7 @@ class XMLFunctions():
         xbmc.executebuiltin( "Skin.SetString(skinshortcuts-sharedmenu,%s)" %( ADDON.getSetting( "shared_menu" ) ) )
             
         # Get the skins addon.xml file
-        addonpath = xbmc.translatePath( os.path.join( "special://skin/", 'addon.xml').encode("utf-8") ).decode("utf-8")
+        addonpath = xbmc.translatePath( os.path.join( "special://skin/", 'addon.xml') )
         addon = xmltree.parse( addonpath )
         extensionpoints = addon.findall( "extension" )
         paths = []
@@ -187,7 +187,7 @@ class XMLFunctions():
             if extensionpoint.attrib.get( "point" ) == "xbmc.gui.skin":
                 resolutions = extensionpoint.findall( "res" )
                 for resolution in resolutions:
-                    path = xbmc.translatePath( os.path.join( "special://skin/", resolution.attrib.get( "folder" ), "script-skinshortcuts-includes.xml").encode("utf-8") ).decode("utf-8")
+                    path = xbmc.translatePath( os.path.join( "special://skin/", resolution.attrib.get( "folder" ), "script-skinshortcuts-includes.xml") )
                     paths.append( path )
                     skinpaths.append( path )
         
@@ -662,7 +662,7 @@ class XMLFunctions():
         progress.update( 100, message = LANGUAGE( 32098 ) )
                 
         # Get the skins addon.xml file
-        addonpath = xbmc.translatePath( os.path.join( "special://skin/", 'addon.xml').encode("utf-8") ).decode("utf-8")
+        addonpath = xbmc.translatePath( os.path.join( "special://skin/", 'addon.xml') )
         addon = xmltree.parse( addonpath )
         extensionpoints = addon.findall( "extension" )
         paths = []
@@ -670,7 +670,7 @@ class XMLFunctions():
             if extensionpoint.attrib.get( "point" ) == "xbmc.gui.skin":
                 resolutions = extensionpoint.findall( "res" )
                 for resolution in resolutions:
-                    path = xbmc.translatePath( os.path.join( try_decode( self.skinDir ) , try_decode( resolution.attrib.get( "folder" ) ), "script-skinshortcuts-includes.xml").encode("utf-8") ).decode('utf-8')
+                    path = xbmc.translatePath( os.path.join( try_decode( self.skinDir ) , try_decode( resolution.attrib.get( "folder" ) ), "script-skinshortcuts-includes.xml") )
                     paths.append( path )
         skinVersion = addon.getroot().attrib.get( "version" )
         
@@ -702,7 +702,7 @@ class XMLFunctions():
         allProps = {}
 
         # Set ID
-        if itemid is not -1:
+        if itemid != -1:
             newelement.set( "id", str( itemid ) )
         idproperty = xmltree.SubElement( newelement, "property" )
         idproperty.set( "name", "id" )
@@ -767,7 +767,7 @@ class XMLFunctions():
                     visibleProperty.text = try_decode( property[1] )                    
                 else:
                     additionalproperty = xmltree.SubElement( newelement, "property" )
-                    additionalproperty.set( "name", property[0].decode( "utf-8" ) )
+                    additionalproperty.set( "name", property[0] )
                     additionalproperty.text = property[1]
                     allProps[ property[ 0 ] ] = additionalproperty
                         
@@ -824,7 +824,7 @@ class XMLFunctions():
 
                     if matches:
                         additionalproperty = xmltree.SubElement( newelement, "property" )
-                        additionalproperty.set( "name", key.decode( "utf-8" ) )
+                        additionalproperty.set( "name", key )
                         additionalproperty.text = propertyMatch[ 0 ]
                         allProps[ key ] = additionalproperty
                         break
@@ -951,19 +951,19 @@ class XMLFunctions():
         
         # If this isn't the main menu, and we're cloning widgets or backgrounds...
         if groupName != "mainmenu":
-            if "clonewidgets" in options and len( self.MAINWIDGET ) is not 0:
+            if "clonewidgets" in options and len( self.MAINWIDGET ) != 0:
                 for key in self.MAINWIDGET:
                     additionalproperty = xmltree.SubElement( newelement, "property" )
                     additionalproperty.set( "name", key )
                     additionalproperty.text = try_decode( self.MAINWIDGET[ key ] )
                     allProps[ key ] = additionalproperty
-            if "clonebackgrounds" in options and len( self.MAINBACKGROUND ) is not 0:
+            if "clonebackgrounds" in options and len( self.MAINBACKGROUND ) != 0:
                 for key in self.MAINBACKGROUND:
                     additionalproperty = xmltree.SubElement( newelement, "property" )
                     additionalproperty.set( "name", key )
                     additionalproperty.text = DATA.local( self.MAINBACKGROUND[ key ] )[1]
                     allProps[ key ] = additionalproperty
-            if "cloneproperties" in options and len( self.MAINPROPERTIES ) is not 0:
+            if "cloneproperties" in options and len( self.MAINPROPERTIES ) != 0:
                 for key in self.MAINPROPERTIES:
                     additionalproperty = xmltree.SubElement( newelement, "property" )
                     additionalproperty.set( "name", key )
@@ -980,8 +980,8 @@ class XMLFunctions():
                     propertyPattern = regexpPattern.sub(replacement, propertyPattern)
     
                 additionalproperty = xmltree.SubElement(newelement, "property")
-                additionalproperty.set("name", propertyName.decode("utf-8"))
-                additionalproperty.text = propertyPattern.decode("utf-8")
+                additionalproperty.set("name", propertyName)
+                additionalproperty.text = propertyPattern
                 allProps[ propertyName ] = additionalproperty
             
         return( newelement, allProps )


### PR DESCRIPTION
First: Where is the version 1.0.19 code? This code repo does not appear up-to-date.

Second: Please consider re-writing this add-on. It's code style needs a serious overhaul.

This is an initial stab at adding Python 3 support. You will need this to get this add-on working with Kodi 19.

Fedora 32 is using a Kodi 18 compiled with Python 3 so I would like to get this add-on updated and pushed to the Kodi 18 repo.